### PR TITLE
Updated -paths_file to support Windows files

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,4 @@ sudo ./ExTerminAttr -addr localhost:6042 -forward_url http://192.168.56.1:8080 /
 ```
 ExTerminAttr -addr <switch-ip>:6042 -forward_url http://localhost:8080 -paths_file paths.cfg
 ```
+paths.cfg file MUST be space delimited.

--- a/main.go
+++ b/main.go
@@ -135,7 +135,7 @@ func loadPaths(pathsFile string) ([]string, error) {
 
 	b, err := ioutil.ReadAll(file)
 	trimmed := strings.TrimSpace(string(b))
-	return strings.Split(trimmed, "\n"), nil
+	return strings.Split(trimmed, " "), nil
 }
 
 func forwardSubscribeResponse(response *pb.SubscribeResponse, forwardURL string) error {


### PR DESCRIPTION
The paths file had to previously be newline delimited and wasn't working for Windows. Making it space delimited work for both Windows, Linux and Mac.